### PR TITLE
Proposing funding changes

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -1337,15 +1337,31 @@ if this is done in good faith on terms no more favourable than if the Member was
 
 1. The funds of the Association may be derived from joining fees, annual subscriptions, donations, fund-raising activities, grants, interest and any other sources approved by the Committee.
 
-2. The Association must only source funds from—
+   2. The Association must only source funds from—
 
-   a. individuals;
+      a. individuals;
 
-   b. community not-for-profit organisations;
+      b. philanthropic grant-giving organisations;
 
-   c. philanthropic grant-giving organisations;
+      c. organisations registered for operation in Australia who, within 6 months of the Fusion donation, are not also donating to any of the following parties (or current candidates of these parties):
 
-   d. funds provided by Governments, Government agencies or agents, for the purposes of supporting candidates or parties to run in elections.
+         i. [The Liberal Party](https://www.liberal.org.au/)
+
+         ii. [The National Party](https://www.nationals.org.au/)
+
+         iii. [The Labor Party](https://www.alp.org.au/)
+
+         iv. [One Nation](https://www.onenation.org.au/)
+
+         v. [Family First Party Australia](https://www.familyfirstparty.org.au/)
+
+         vi. [Gerard Rennick People First](https://peoplefirstparty.au/policies/)
+
+         viii. [Democratic Party](https://democrats.org/) (USA)
+
+         ix. [Republican Party](https://en.wikipedia.org/wiki/Republican_Party_(United_States)) (USA)
+
+      d. funds provided by Governments, Government agencies or agents, for the purposes of supporting candidates or parties to run in elections.
 
 3. The Association must not source funds from any source whose purposes or policies run counter to the Association's purposes, policies or strategies with the exception of funding sourced from sources identified in sub-rule (2)(d).
 


### PR DESCRIPTION
I'm proposing these changes because I feel that we're significantly restricting ourselves, beyond a point that the public cares about.

People still vote for Liberal and Labor despite them accepting donations from Santos, and here we are saying we're not going to accept money from any profit-driven company. We need funds to compete in elections, and it's not like our performance previously has been strong enough that we can afford to turn away a big chunk of potential donors.

I'm therefore revising the restrictions so that we avoid accepting donations from people who would seem to be requesting favours that would compromise our values.

There have been plenty of allegations of US politicians trading on insider knowledge. There have been allegations of Liberal, Nationals and Labor MPs doing corrupt favours for Australians. So if anyone donates to such parties, then to us, the public could readily interpret this donation to be a request for Fusion to carry out favours for them. And the public would presume that this donor is not a chump − they'd presume there's a good likelihood of us fulfilling this favour.

There are some other parties here which I've included simply because their policies clash so fundamentally with our stance on climate. One Nation for instance wishes to scrap the [fuel excise](https://www.onenation.org.au/cut-fuel-tax#:~:text=Australian%20motorists%20paid%20more%20than%20%2415%20billion%20in,the%20prices%20we%20pay%20for%20virtually%20everything%20else.), thereby encouraging greater use of fossil fuels for transport.

If someone donates to a climate-denial party and to Fusion, it's hard to imagine them being perceived as a true believer. The explanation more likely to take root is that they're making an each-way bet and are looking for political favouritism from whoever ends up winning the election.